### PR TITLE
#82 force-revoke 時に exh_id を null にするようにした

### DIFF
--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -63,7 +63,8 @@ class Reservation extends Model {
     public function revokeAllGuests() {
         $modified = self::guest()->whereNull('revoked_at')->update([
             'revoked_at' => Carbon::now(),
-            'is_force_revoked' => true
+            'is_force_revoked' => true,
+            'exhibition_id' => null,
         ]);
         if ($modified) {
             Log::info("{$modified} guest has revoked.");


### PR DESCRIPTION
fix: #82

本当は revoke 時にする〜、みたいに書いた方がいいんかな、、
